### PR TITLE
Reworked Gold a little bit

### DIFF
--- a/game/scripts/vscripts/components/gold/gold.lua
+++ b/game/scripts/vscripts/components/gold/gold.lua
@@ -29,6 +29,8 @@ local PLAYER_GOLD = {
   [9] = {}
 }
 
+local GOLD_CAP = 50000
+
 function Gold:Init()
   -- a table for every player
   PlayerTables:CreateTable("gold", {
@@ -67,10 +69,28 @@ function Gold:Think()
   for i = 0, 9 do
     if PlayerResource:IsValidPlayerID(i) then
       if GameRules:State_Get() == DOTA_GAMERULES_STATE_GAME_IN_PROGRESS then
-        local goldtoadd = PlayerResource:GetGold(i)
-        if goldtoadd ~= 0 then
-          Gold:AddGold(i, goldtoadd)
-          PlayerResource:SetGold(i, 0, false)
+        
+        local currentGold = Gold:GetGold(i)
+        local currentDotaGold = PlayerResource:GetGold(i)
+
+        local newGold = currentGold
+        local newDotaGold = currentDotaGold
+        
+        if currentGold > GOLD_CAP then
+          newGold = currentGold + currentDotaGold - GOLD_CAP
+        else
+          newGold = currentDotaGold
+        end
+
+        if newGold > GOLD_CAP then
+          newDotaGold = GOLD_CAP
+        else
+          newDotaGold = newGold
+        end
+
+        if newGold ~= currentGold or newDotaGold ~= currentDotaGold then
+          Gold:SetGold(i, newGold)
+          PlayerResource:SetGold(i, newDotaGold, false)
         end
       end
     end


### PR DESCRIPTION
Modify the current implementation of the custom gold, so that it doesn't
keep dota gold at 0, but keeps the dota gold between 0 and 50000. This
way, you can make all the shop purchases work as normal.

Please note that in this kind of system purchasing items that cost more
than 50000 is impossible if they can't be combined from other items...
If they do combine, it is still not possible to buy it directly, but you
must by the "parts" first until the "gold to complete" is lower than
50000.

Of course, you could make the limit higher. Let's say 80000 or 90000 for
example... It pretty much depends on how much "dota bounty" you get from
regular dota events (player kills for example).