### PR TITLE
Fix for 6 level abilities in HUD #90

### DIFF
--- a/content/panorama/styles/hud/dota_hud_ability_panel.css
+++ b/content/panorama/styles/hud/dota_hud_ability_panel.css
@@ -1675,7 +1675,8 @@ DOTAAbilityPanel.Hidden
 /* Added for AAA*/
 .Reborn .AbilityMaxLevel6 .LevelPanel
 {
-  margin: 3px 1px 3px 1px;
+  width: 7px;
+  margin: 3px 1.5px 3px 1.5px;
 }
 
 

--- a/content/panorama/styles/hud/dota_hud_ability_panel.css
+++ b/content/panorama/styles/hud/dota_hud_ability_panel.css
@@ -1,0 +1,2453 @@
+@define unlearnedWashColor: #666666;
+
+DOTAAbilityPanel
+{
+	visibility: visible;
+	transition-property: width;
+	transition-duration: 0s;
+	transition-timing-function: ease-in-out;
+	transition-timing-function: linear;
+}
+
+DOTAAbilityPanel.Hidden
+{
+	width: 0px;
+}
+
+#UpgradeOverlay
+{
+	background-image: url("s2r://panorama/images/hud/learnspell_png.vtex");
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	margin: 2px;
+}
+
+.show_level_up_frame #UpgradeOverlay
+{
+	opacity: 1.0;
+}
+
+#ActiveAbilityBorder
+{
+	background-image: url("s2r://panorama/images/hud/active_ability_border_png.vtex");
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+	opacity: 1.0;
+	margin: 2px;
+}
+
+.can_cast_again #ActiveAbilityBorder
+{
+	background-image: url("s2r://panorama/images/hud/active_ability_border_down_png.vtex");
+}
+
+.no_level #ActiveAbilityBorder:not(.show_level_up_frame)
+{
+	brightness: 0.2;
+}
+
+.show_level_up_frame #ActiveAbilityBorder
+{
+	opacity: 0.0;
+}
+
+.is_passive #ActiveAbilityBorder
+{
+	opacity: 0.0;
+}
+
+#PassiveAbilityBorder
+{
+	background-image: url("s2r://panorama/images/hud/passive_ability_border_png.vtex");
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+	opacity: 0.0;
+	margin: 7px;
+}
+
+.is_passive #PassiveAbilityBorder
+{
+	opacity: 1.0;
+}
+
+#TopBarUltimate.is_passive #PassiveAbilityBorder
+{
+	opacity: 0.0;
+}
+
+
+.can_cast_again #PassiveAbilityBorder
+{
+	background-image: url("s2r://panorama/images/hud/passive_ability_border_down_png.vtex");
+	margin: 8px;
+}
+
+#AutocastableAbilityBorder
+{
+	background-image: url("s2r://panorama/images/hud/autocastable_ability_border_png.vtex");
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+	opacity: 0.0;
+}
+
+.auto_castable #AutocastableAbilityBorder
+{
+	opacity: 1.0;
+}
+
+#SilencedOverlay
+{
+	background-image: url("s2r://panorama/images/hud/reborn/spells_silenced_psd.vtex");
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	margin: 2px;
+	pre-transform-scale2d: 1.2;
+
+	transition-property: opacity, pre-transform-scale2d;
+	transition-timing-function: ease-in-out;
+	transition-duration: .22s;
+}
+
+.silenced #SilencedOverlay
+{
+	opacity: 1.0;
+	pre-transform-scale2d: 1;
+}
+
+#CombineLockedOverlay
+{
+	background-image: url("s2r://panorama/images/hud/reborn/item_combine_lock_psd.vtex");
+	background-size: 100% 100%;
+	width: 16px;
+	height: 16px;
+	horizontal-align: right;
+	opacity: 0;
+	margin: 3px;
+	margin-right: 3px;
+}
+
+.combine_locked #CombineLockedOverlay
+{
+	opacity: 1.0;
+}
+
+
+#RecommendedUpgradeOverlay
+{
+	width: 100%;
+	height: 100%;
+	margin: 1px;
+	opacity: 0;
+	tooltip-position: top;
+	tooltip-body-position: 0% 50%;
+}
+
+.recommended_upgrade #RecommendedUpgradeOverlay
+{
+	opacity: 1.0;
+}
+
+#AbilityStatusOverlay
+{
+	width: 100%;
+	height: 100%;
+	border: 2px solid transparent;
+}
+
+.auto_cast_enabled #AbilityStatusOverlay
+{
+	border: 2px solid orange;
+}
+
+.toggle_enabled #AbilityStatusOverlay
+{
+	border: 2px solid green;
+}
+
+.ability_phase #AbilityStatusOverlay
+{
+	border: 2px solid yellow;
+}
+
+#ButtonAndLevel
+{
+	flow-children: none;
+}
+
+#abilities #ButtonAndLevel
+{
+	height: 180px;
+	horizontal-align: center;
+}
+
+#ButtonWithLevelUpTab
+{
+	flow-children: none;
+	vertical-align: bottom;
+	height: fit-children;
+}
+
+#abilities #ButtonWithLevelUpTab
+{
+	margin-bottom: 12px;
+	margin-bottom: 25px;
+	height: 104px;
+}
+
+@keyframes 'leveluptabpulseglow'
+{
+	0%
+	{
+		background-color: #97B1DD;
+	}
+
+
+	50%
+	{
+		background-color: #6783AB;
+	}
+
+	100%
+	{
+		background-color: #97B1DD;
+	}
+}
+
+.show_level_up_tab #ButtonWithLevelUpTab
+{
+	background-color: none;
+}
+
+#LevelUpTab
+{
+	width: 100%;
+	height: 36px;
+
+	margin-bottom: -4px;
+	opacity: 0;
+
+	tooltip-position: top;
+	tooltip-body-position: 50% 50%;
+
+	z-index: 2;
+	transition-property: opacity, brightness;
+	transition-timing-function: ease-in-out;
+	transition-duration: .12s;
+
+}
+
+#LevelUpButton
+{
+	width: 100%;
+	height: 36px;
+
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_button_psd.vtex");
+	background-size: 100% 100%;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+
+	transition-property: opacity, brightness, pre-transform-scale2d;
+	transition-timing-function: ease-in-out;
+	transition-duration: .12s;
+
+	margin-bottom: -4px;
+}
+
+#LearnModeButton
+{
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_button_learnmode_psd.vtex");
+	height: 92px;
+	width: 72px;
+
+	horizontal-align: center;
+	margin-top: 14px;
+	z-index: 6;
+
+	background-size: 100% 100%;
+	background-position: 100% 100%;
+	background-repeat: no-repeat;
+
+	visibility: collapse;
+
+	transition-property: opacity, brightness, pre-transform-scale2d;
+	transition-timing-function: ease-in-out;
+	transition-duration: .12s;
+
+}
+
+.AbilityLearnMode #LearnModeButton
+{
+	visibility: visible;
+}
+
+.AbilityLearnMode #LevelUpTab
+{
+	height: 156px;
+}
+
+
+#Ability0 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_2_psd.vtex"); }
+#Ability1 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_2_psd.vtex"); }
+#Ability2 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_4_psd.vtex"); }
+#Ability3 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_5_psd.vtex"); }
+
+.FiveAbilities #Ability2 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_3_psd.vtex"); }
+.FiveAbilities #Ability3 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_4_psd.vtex"); }
+.FiveAbilities #Ability4 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_5_psd.vtex"); }
+
+
+.SixAbilities #Ability2 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_3_psd.vtex"); }
+.SixAbilities #Ability3 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_3_psd.vtex"); }
+.SixAbilities #Ability4 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_4_psd.vtex"); }
+.SixAbilities #Ability5 #LevelUpButton { background-image: url("s2r://panorama/images/hud/reborn/levelup_button_5_psd.vtex"); }
+
+
+.SixAbilities .npc_dota_hero_morphling #Ability2 #LevelUpButton,
+.SixAbilities .npc_dota_hero_morphling #Ability3 #LevelUpButton
+{
+	margin-bottom: 0px;
+	margin-top: 0px;
+}
+
+#LevelUpTab:hover #LevelUpButton
+{
+	brightness: 1.4;
+}
+
+#LevelUpTab:active #LevelUpButton
+{
+	pre-transform-scale2d: .9;
+}
+
+#LevelUpLight
+{
+	width: 100%;
+	height: 82px;
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_lightcast_psd.vtex");
+	background-size: 100% 100%;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	margin-top: 30px;
+	z-index: 0 ;
+	opacity: 0;
+	transition-property: opacity;
+	transition-timing-function: ease-in-out;
+	transition-duration: .32s;
+}
+
+.auto_castable #LevelUpLight
+{
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_lightcast_autocast_psd.vtex");
+	z-index: 1;
+}
+
+.auto_castable.no_level #LevelUpLight
+{
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_lightcast_autocast_ul_psd.vtex");
+	z-index: 1;
+}
+
+
+.show_level_up_tab #LevelUpLight
+{
+	opacity: 1;
+}
+
+#LevelUpIcon
+{
+	horizontal-align: center;
+	vertical-align: middle;
+	width: 24px;
+	height: 24px;
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_plus_well_psd.vtex");
+	background-size: 100% 100%;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	transition-property: background-image;
+	transition-duration: .12s;
+}
+
+#LevelUpTab:hover #LevelUpIcon
+{
+	background-image: url("s2r://panorama/images/hud/reborn/levelup_plus_fill_psd.vtex");
+}
+
+.show_level_up_tab #LevelUpTab
+{
+	opacity: 1;
+}
+
+#ButtonSize
+{
+	width: 90px;
+	height: 90px;
+	transition-property: box-shadow;
+	transition-duration: .2s;
+	transition-timing-function: ease-in-out;
+}
+
+.FiveAbilities #ButtonSize
+{
+	width: 80px;
+	height: 80px;
+}
+
+.SixAbilities #ButtonSize
+{
+	width: 70px;
+	height: 72px;
+}
+
+#AbilityButton
+{
+	width: 100%;
+	height: 100%;
+
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #00000000 ), to( #00000000 ) );
+	transition-property: pre-transform-scale2d, brightness, saturation, background-color, opacity;
+	transition-duration: .06s, .1s;
+	transition-timing-function: ease-out;
+
+}
+
+.is_passive #AbilityButton
+{
+	//box-shadow: inset #000000bb 6px 6px 12px 12px;
+}
+
+#AbilityButton:hover
+{
+	brightness: 1.6;
+}
+
+#AbilityButton:active
+{
+
+}
+
+#AbilityImage
+{
+	width: 100%;
+	height: 100%;
+	z-index: -1;
+	margin: 9px;
+
+	transition-property: pre-transform-scale2d;
+	transition-duration: .12s;
+	transition-timing-function: ease-in;
+}
+
+.muted #AbilityImage
+{
+	saturation: .6;
+}
+
+.no_level:not(.show_level_up_frame) #AbilityImage
+{
+	saturation: 0;
+	wash-color: unlearnedWashColor;
+}
+
+.insufficient_mana #AbilityImage
+{
+	saturation: 0;
+	wash-color: #1569be;
+	contrast: .7;
+}
+
+.potential_upgrade.no_level #AbilityImage
+{
+	saturation: 1;
+	wash-color: white;
+}
+
+.can_cast_again:not(.InventoryItem) #AbilityImage
+{
+	pre-transform-scale2d: 0.9;
+}
+
+.is_passive.can_cast_again:not(.InventoryItem) #AbilityImage
+{
+	pre-transform-scale2d: 0.9;
+}
+
+#ItemImage
+{
+	width: 100%;
+	height: 100%;
+	visibility: collapse;
+	z-index: -1;
+}
+
+
+
+.insufficient_mana:not(.muted) #ItemImage
+{
+	saturation: 0;
+	wash-color: #1569be;
+}
+
+#Cooldown
+{
+	width: 100%;
+	height: 100%;
+	visibility: collapse;
+	margin: 5px;
+}
+
+.in_cooldown #Cooldown
+{
+	visibility: visible;
+}
+
+#CooldownOverlay
+{
+	width: 100%;
+	height: 100%;
+	background-color: #000000DD;
+
+	transition-property: clip;
+	transition-duration: 0.06s;
+	transition-timing-function: linear;
+}
+
+#InactiveOverlay
+{
+	width: 100%;
+	height: 100%;
+    background-color: black;
+    visibility: collapse;
+    opacity: 0.1;
+}
+
+.inactive_item #AbilityButton
+{
+    saturation: 0.0;
+    brightness: 0.9;
+	contrast: .95;
+}
+
+.inactive_item #InactiveOverlay
+{
+    //visibility: visible;
+}
+
+#CooldownTimer
+{
+	color: white;
+    font-size: 28px;
+	text-shadow: 0px 0px 6px 6 #000000;
+	width: 100%;
+    text-align: center;
+    vertical-align: center;
+	text-overflow: shrink;
+}
+
+#Charges
+{
+	color: #ffffff;
+    font-size: 16px;
+    font-weight: bold;
+	visibility: collapse;
+	vertical-align: bottom;
+	horizontal-align: right;
+	visibility: collapse;
+	margin-right: 3px;
+	margin-bottom: -3px;
+	text-shadow: 0px 0px 3px 4 #000000;
+    font-family: RadianceM;
+}
+
+.BackpackSlot #Charges
+{
+	margin-right: 9px;
+	margin-bottom: 4px;
+	text-shadow: none;
+	text-shadow: 0px 0px 1px 3 #000000;
+}
+
+.QueryUnit .BackpackSlot #Charges
+{
+	margin-right: 2px;
+	margin-bottom: 2px;
+	font-size: 14px;
+}
+
+.show_charges #Charges
+{
+	visibility: visible;
+}
+
+#AltCharges
+{
+	color: #999999;
+    font-size: 14px;
+	visibility: collapse;
+	vertical-align: bottom;
+	horizontal-align: left;
+    font-weight: bold;
+    margin-left: 3px;
+    font-family: RadianceM;
+}
+
+.show_alt_charges #AltCharges
+{
+	visibility: visible;
+}
+
+#ActiveAbility
+{
+	width: 100%;
+	height: 100%;
+	background-color: gradient( radial, 50% -20%, 0% 0%, 80% 80%, from( #FFFFFF08 ), to( #FFFFFF08 ) );
+	border: 4px solid #FFFFFF40;
+	opacity: 0;
+}
+
+.is_active #ActiveAbility
+{
+	opacity: 1;
+}
+
+#ManaCost
+{
+	color: #c0e8fb;
+    font-size: 14px;
+    font-weight: bold;
+	text-shadow: 0px 0px 3px 3.0 #000000;
+	margin-right: 7px;
+	margin-bottom: 6px;
+
+	vertical-align: bottom;
+	horizontal-align: right;
+}
+
+#ManaCostBG
+{
+	width: 37px;
+	height: 22px;
+	margin-right: -1px;
+	margin-bottom: 0px;
+
+	vertical-align: bottom;
+	horizontal-align: right;
+
+	background-image: url("s2r://panorama/images/hud/manaamount_bg_png.vtex");
+	background-size: 100% 100%;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+}
+
+.no_mana_cost #ManaCost,
+.no_mana_cost #ManaCostBG
+{
+	visibility: collapse;
+}
+
+#GoldCost
+{
+	color: #FFFF99;
+    font-size: 14px;
+    font-weight: bold;
+	text-shadow: 0px 0px 3px 3.0 #000000;
+	margin-left: 13px;
+	margin-bottom: 6px;
+
+	vertical-align: bottom;
+	horizontal-align: left;
+}
+
+#GoldCostBG
+{
+	width: 37px;
+	height: 22px;
+	margin-left: 6px;
+	margin-bottom: 0px;
+
+	vertical-align: bottom;
+	horizontal-align: left;
+
+	background-image: url("s2r://panorama/images/hud/goldamount_bg_png.vtex");
+	background-size: 100% 100%;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+}
+
+.no_gold_cost #GoldCost,
+.no_gold_cost #GoldCostBG
+{
+	visibility: collapse;
+}
+
+#HotkeyContainer
+{
+	width: 100%;
+	height: 100%;
+	margin-left: 1px;
+	z-index: 5;
+}
+
+.FiveAbilities #HotkeyContainer,
+.SixAbilities #HotkeyContainer
+{
+	margin-left: 0px;
+}
+
+#abilities #HotkeyContainer
+{
+	margin-top: 41px;
+	border: 0px solid white;
+}
+
+#Hotkey
+{
+	margin-left: -4px;
+	z-index: 16;
+	border-radius: 20%;
+
+	vertical-align: top;
+	horizontal-align: left;
+	min-width: 14px;
+	min-height: 14px;
+	max-width: 70px;
+	white-space: nowrap;
+
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #393939 ), to( #414849 ) );
+	border: 1px solid #ffffff05;
+	box-shadow: fill black 1px 1px 2px 2px;
+}
+
+#HotkeyText
+{
+	color: #bba995;
+ 	text-shadow: 1px 1px 0px 2 #000000;
+    font-size: 12px;
+    font-weight: normal;
+	text-align: center;
+	horizontal-align: center;
+	margin: 0px 0px -2px 0px;
+}
+
+#HotkeyModifier
+{
+	margin-left: -4px;
+	margin-top: 20px;
+	z-index: 16;
+	vertical-align: top;
+	horizontal-align: left;
+	min-width: 18px;
+	flow-children: down;
+
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #393939 ), to( #414849 ) );
+	border: 1px solid #ffffff05;
+	box-shadow: fill black 1px 1px 2px 2px;
+
+	visibility: collapse;
+}
+
+.hotkey_alt #HotkeyModifier
+{
+	visibility: visible;
+}
+
+#AltText
+{
+	color: #bba995;
+ 	text-shadow: 1px 1px 2px 2 #000000;
+    font-size: 8px;
+    font-weight: normal;
+	text-align: center;
+	width: 100%;
+	margin: 0px -2px -2px -1px;
+	visibility: visible;
+}
+
+#HotkeyCtrlModifier
+{
+	margin-left: 0px;
+	margin-top: 0px;
+	z-index: 15;
+	vertical-align: top;
+	horizontal-align: left;
+	min-width: 31px;
+
+	background-color: #212726;
+	border-radius: 4px;
+	border: 1px solid black;
+	box-shadow: fill #000000dd 0px 0px 2px 2px;
+
+	visibility: collapse;
+}
+
+.hotkey_ctrl #HotkeyCtrlModifier
+{
+	visibility: visible;
+}
+
+.QueryUnit .hotkey_ctrl #HotkeyCtrlModifier
+{
+	visibility: collapse;
+}
+
+.LowVisualQuality #HotkeyCtrlModifier
+{
+	border-radius: 0px;
+}
+
+#CtrlText
+{
+	color: white;
+ 	text-shadow: 1px 1px 2px 2 #000000;
+    font-size: 12px;
+    font-weight: normal;
+	text-align: center;
+	width: 100%;
+	margin: 0px -2px -2px -1px;
+	visibility: visible;
+}
+
+.no_level:not(.show_level_up_tab) #HotKey,
+.no_level:not(.show_level_up_tab) #HotKeyModifier
+{
+	visibility: collapse;
+}
+
+.is_passive:not(.show_level_up_tab) #HotKey,
+.is_passive:not(.show_level_up_tab) #HotKeyModifier
+{
+	visibility: collapse;
+}
+
+.no_item #Hotkey,
+#stash_row #Hotkey,
+.no_hotkey #Hotkey,
+.no_item #HotkeyModifier,
+#stash_row #HotkeyModifier,
+.no_hotkey #HotkeyModifier
+{
+	visibility: collapse;
+}
+
+#AbilityLevelContainer
+{
+	margin-top: 4px;
+	horizontal-align: center;
+	vertical-align: bottom;
+	flow-children: right;
+	background-color: black;
+	width: 100%;
+}
+
+
+.LevelPanel
+{
+	width: 17px;
+	height: 16px;
+
+	background-image: url("s2r://panorama/images/hud/pip_off_png.vtex");
+	background-size: 100% 100%;
+
+	visibility: visible;
+}
+
+.AbilityMaxLevel7 .LevelPanel
+{
+	width: 9px;
+	height: 9px;
+}
+
+.active_level.LevelPanel
+{
+	background-image: url("s2r://panorama/images/hud/pip_on_png.vtex");
+	background-size: 75% 75%;
+	background-position: 50% 35%;
+	background-repeat: no-repeat;
+}
+
+.could_level_up .next_level.LevelPanel
+{
+	background-image: url("s2r://panorama/images/hud/pip_outline_png.vtex");
+}
+
+.ActiveLevelPanel
+{
+	visibility: collapse;
+}
+
+.Hidden.LevelPanel
+{
+	visibility: collapse;
+}
+
+#ShineContainer
+{
+	width: 100%;
+	height: 100%;
+	margin: 5px;
+}
+
+.is_passive #ShineContainer
+{
+	margin: 7px;
+}
+
+#Shine
+{
+	background-color: gradient( linear, 100% 0%, 0% 100%, from( #00000000 ), color-stop( 0.3, #00000000 ), color-stop( 0.45, #ffffffff ), color-stop( 0.55, #ffffffff ), color-stop( 0.7, #00000000 ), to( #00000000 ) );
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+
+	opacity: 0.00001;
+	animation-name: none;
+	animation-duration: 0.4s;
+	animation-timing-function: ease-in-out;
+}
+
+#Shine.do_shine
+{
+	animation-name: shine-sweep;
+	animation-duration: 0.4s;
+}
+
+@keyframes 'shine-sweep'
+{
+	0%
+	{
+		transform: translateX(-32px) translateY(32px);
+		opacity: 1.0;
+	}
+
+	100%
+	{
+		transform: translateX(32px) translateY(-32px);
+		opacity: 1.0;
+	}
+}
+
+
+// ============================================================================
+// Alternate styling for inventory items
+// ============================================================================
+
+.InventoryItem #AbilityImage
+{
+	visibility: collapse;
+}
+
+.InventoryItem #ItemImage
+{
+	visibility: visible;
+	//border: 1px solid black;
+}
+
+.InventoryItem.BackpackSlot #ItemImage
+{
+	margin-top: 4px;
+	margin-bottom: 4px;
+	margin: 6px;
+}
+
+
+.muted #ItemImage
+{
+	saturation: 0.6;
+}
+
+.InventoryItem #ButtonSize
+{
+	width: 71px;
+	height: 54px;
+	margin-left: 4px;
+	margin-right: 4px;
+	margin-top: 4px;
+	margin-bottom: 4px;
+}
+
+.InventoryItem.Stash #ButtonSize
+{
+	width: 52px;
+	height: 39px;
+	margin-left: 3px;
+	margin-right: 3px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+
+.InventoryItem #Hotkey
+{
+	margin-left: 0px;
+	min-width: 14px;
+	min-height: 14px;
+}
+
+.InventoryItem #HotkeyModifier
+{
+	margin-left: 0px;
+}
+
+.InventoryItem #AbilityLevelContainer
+{
+	visibility: collapse;
+}
+
+.dragging_from #AbilityButton
+{
+	saturation: 0.5;
+	wash-color: #808080;
+	opacity: .35;
+	pre-transform-scale2d: .9;
+}
+
+.dragging_from.BackpackSlot #AbilityButton
+{
+	saturation: 0;
+}
+
+.Reborn .InventoryItem.dragging_from:not(.no_level) #ButtonSize
+{
+	background-image: url("s2r://panorama/images/hud/reborn/inventory_item_well_psd.vtex");
+	background-size: cover;
+	box-shadow: fill #00000000 -5px -5px 8px 8px;
+}
+
+
+.Reborn .is_passive.dragging_from #ButtonWell
+{
+
+}
+
+.dragging_from #DropTargetHighlight
+{
+	visibility: collapse;
+}
+
+#DropTargetHighlight
+{
+	margin-top: 1px;
+	margin-left: 1px;
+	width: 100%;
+	height: 100%;
+	background-color: gradient( radial, 50% -20%, 0% 0%, 80% 100%, from( #FFFFFF66 ), to( #FFFFFF00 ) );
+	opacity: 0;
+}
+
+.potential_drop_target #DropTargetHighlight
+{
+	opacity: 0.3;
+}
+
+.Reborn .InventoryItem #ManaCost
+{
+	margin-right: 2px;
+	margin-bottom: -2px;
+}
+
+.Reborn .InventoryItem #ManaCostBG
+{
+	margin-right: -9px;
+	margin-bottom: -8px;
+}
+
+.Reborn .InventoryItem.BackpackSlot #ManaCost,
+.Reborn .InventoryItem.BackpackSlot #ManaCostBG,
+.Reborn .InventoryItem.show_charges #ManaCost,
+.Reborn .InventoryItem.show_charges #ManaCostBG
+{
+	visibility: collapse;
+}
+
+.InventoryItem #ActiveAbilityBorder
+{
+	visibility: collapse;
+}
+
+.InventoryItem #PassiveAbilityBorder
+{
+	visibility: collapse;
+}
+
+.InventoryItem #AutocastableAbilityBorder
+{
+	visibility: collapse;
+}
+
+.InventoryItem #RecommendedUpgradeOverlay
+{
+	visibility: collapse;
+}
+
+.InventoryItem #SilencedOverlay
+{
+	visibility: collapse;
+}
+
+.InventoryItem #Cooldown
+{
+	margin: 0px;
+}
+
+.InventoryItem #CooldownTimer
+{
+	font-size: 16px;
+    text-shadow: 0px 0px 3px 3.7 #000000FF;
+    margin-top:1px;
+}
+
+.InventoryItem #ShineContainer
+{
+	margin: 0px;
+}
+
+.toggle_enabled.InventoryItem  #AbilityStatusOverlay
+{
+	border: 0px;
+}
+
+//----------------------------------------------------------------------
+// Reborn HUD
+
+.Reborn DOTAAbilityPanel
+{
+	//margin-right: 1px;
+	vertical-align: bottom;
+}
+
+.Reborn #ActiveAbilityBorder
+{
+    background-image: url("s2r://panorama/images/hud/reborn/active_ability_border_psd.vtex");
+    margin: 0px;
+	visibility: collapse;
+}
+
+.Reborn .auto_castable #AutocastableAbilityBorder
+{
+	background-image: url("s2r://panorama/images/hud/reborn/autocastable_ability_border_psd.vtex");
+	opacity: 0;
+}
+
+.Reborn .auto_castable #AutocastableBorder
+{
+	background-image: url("s2r://panorama/images/hud/reborn/autocastable_ability_border_psd.vtex");
+	background-size: 100% 100%;
+	width: 100%;
+	height: 100%;
+	opacity: 1.0;
+	margin: 3px;
+	//margin-right: 1.5px;
+	//margin-bottom: 4px;
+	transition-property: background-image;
+	transition-duration: .16s;
+	transition-timing-function: ease-in-out;
+}
+
+.AspectRatio16x10 .auto_castable #AutocastableBorder
+{
+	margin-bottom: 4px;
+}
+
+.Reborn .SixAbilities .auto_castable #AutocastableBorder,
+.Reborn .FiveAbilities .auto_castable #AutocastableBorder
+{
+	margin: 0px;
+}
+
+
+.Reborn .auto_cast_enabled.auto_castable #AutocastableBorder
+{
+	background-image: url("s2r://panorama/images/hud/reborn/autocastable_ability_border_active_psd.vtex");
+}
+
+.Reborn #PassiveAbilityBorder
+{
+//	visibility: collapse;
+}
+
+.Reborn #abilities #AbilityImage,
+.Reborn #abilities #Cooldown
+{
+	margin: 7px;
+	//margin: 0px;
+}
+
+
+.Reborn #inventory #ItemImage
+{
+//	margin: 0px;
+
+}
+
+.Reborn .insufficient_mana #ItemImage
+{
+	pre-transform-scale2d: 1;
+	contrast: .79;
+	saturation: .5;
+	wash-color: #000000a4;
+	saturation: 0;
+	wash-color: #1569be;
+	contrast: .7;
+}
+
+.Reborn #ButtonSize
+{
+	width: 64px;
+	height: 64px;
+	horizontal-align: center;
+	vertical-align: middle;
+}
+
+.auto_castable #ButtonSize
+{
+	width: 58px;
+	height: 58px;
+}
+
+.AspectRatio16x10 .auto_castable #ButtonSize
+{
+	margin-right: 1px;
+	margin-bottom: 1px;
+}
+
+
+
+//   FIVE SIX ABILITIES =============================================================================
+
+.Reborn .FiveAbilities #abilities #ButtonSize,
+.Reborn .SixAbilities #abilities #ButtonSize
+{
+	width: 58px;
+	height: 58px;
+	horizontal-align: center;
+	vertical-align: middle;
+}
+
+.Reborn .FiveAbilities #abilities .auto_castable #ButtonSize,
+.Reborn .SixAbilities #abilities .auto_castable #ButtonSize
+{
+	width: 48px;
+	height: 48px;
+	horizontal-align: center;
+	vertical-align: middle;
+}
+
+.Reborn .FiveAbilities #abilities #ButtonWell,
+.Reborn .SixAbilities #abilities #ButtonWell
+{
+	width: 54px;
+	height: 54px;
+	margin-bottom: 8px;
+}
+
+.Reborn .FiveAbilities #abilities #AbilityImage,
+.Reborn .SixAbilities #abilities #AbilityImage,
+.Reborn .FiveAbilities #abilities #Cooldown,
+.Reborn .SixAbilities #abilities #Cooldown
+{
+	margin: 3px;
+}
+
+.Reborn .FiveAbilities #abilities #AbilityBevel,
+.Reborn .SixAbilities #abilities #AbilityBevel
+{
+	margin: 2px;
+}
+
+.Reborn .FiveAbilities #abilities #ButtonWithLevelUpTab,
+.Reborn .SixAbilities #abilities #ButtonWithLevelUpTab
+{
+	margin-bottom: 24px;
+}
+
+.Reborn .FiveAbilities #abilities #ManaCostBG,
+.Reborn .SixAbilities #abilities #ManaCostBG
+{
+	margin-right: -5px;
+	margin-bottom: -4px;
+}
+
+.Reborn .FiveAbilities #abilities #ManaCost,
+.Reborn .SixAbilities #abilities #ManaCost
+{
+	margin-right: 3px;
+	margin-bottom: 1px;
+}
+
+.Reborn .FiveAbilities #abilities #PassiveAbilityBorder,
+.Reborn .SixAbilities #abilities #PassiveAbilityBorder
+{
+	margin: 2px;
+}
+
+.Reborn .FiveAbilities #abilities #LevelUpLight,
+.Reborn .SixAbilities #abilities #LevelUpLight
+{
+	background-position: 0px 2px;
+}
+
+.Reborn .FiveAbilities .npc_dota_hero_morphling #abilities #Ability2 #LevelUpLight,
+.Reborn .SixAbilities .npc_dota_hero_morphling #abilities #Ability2 #LevelUpLight,
+.Reborn .FiveAbilities .npc_dota_hero_morphling #abilities #Ability3 #LevelUpLight,
+.Reborn .SixAbilities .npc_dota_hero_morphling #abilities #Ability3 #LevelUpLight
+{
+	background-position: 0px 12px;
+}
+
+.Reborn .FiveAbilities #abilities #AbilityLevelContainer,
+.Reborn .SixAbilities #abilities #AbilityLevelContainer
+{
+	margin-bottom: 20px;
+}
+
+//====================================================================================================
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #ButtonWell,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #ButtonWell,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #ButtonWell,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #ButtonWell
+{
+	width: 44px;
+	height: 44px;
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #ButtonSize,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #ButtonSize,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #ButtonSize,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #ButtonSize
+{
+	width: 54px;
+	height: 54px;
+
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #ButtonWithLevelUpTab,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #ButtonWithLevelUpTab,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #ButtonWithLevelUpTab,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #ButtonWithLevelUpTab
+{
+	margin-bottom: 34.5px;
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #AbilityBevel,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #AbilityBevel,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #AbilityImage,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #AbilityImage,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #AbilityBevel,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #AbilityBevel,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #AbilityImage,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #AbilityImage
+{
+	margin: 2px;
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 .LevelPanel,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 .LevelPanel,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 .LevelPanel,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 .LevelPanel
+{
+	width: 4px;
+}
+
+.HeroStatValue
+{
+	visibility: collapse;
+	vertical-align: bottom;
+	font-size: 12px;
+	font-weight: thin;
+	margin-left: 6px;
+	margin-bottom: 2px;
+	color: #00dd00;
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #AgiValue,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #StrValue,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #AgiValue,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #StrValue
+{
+	visibility: visible;
+	text-shadow: 0px 0px 3px 3 #000000;
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 .HeroStatValue,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 .HeroStatValue
+{
+	horizontal-align: right;
+	margin-right: 4px;
+	color: #dd0000;
+}
+
+.Reborn .HasMorph .toggle_enabled .HeroStatValue
+{
+	font-weight: bold;
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #LevelUpTab,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #LevelUpTab,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #LevelUpTab,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #LevelUpTab
+{
+	margin-top: 21px;
+	margin-top: 10px;
+}
+
+.Reborn #AutoCastingContainer
+{
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	transition-property: opacity;
+	transition-duration: .12s;
+	transition-timing-function: ease-in-out;
+}
+
+.Reborn .auto_cast_enabled #AutoCastingContainer
+{
+	opacity: 1;
+}
+
+#AutoCasting
+{
+	width: 100%;
+	height: 100%;
+}
+
+.Reborn .auto_cast_enabled #AbilityStatusOverlay
+{
+	border: 0px solid transparent;
+}
+
+.Reborn #inventory #AutoCasting
+{
+	visibility: collapse;
+}
+
+#AbilityBevel
+{
+	visibility: collapse;
+}
+
+.Reborn #AbilityBevel
+{
+	width: 100%;
+	height: 100%;
+	margin: 5px;
+	background-image: url("s2r://panorama/images/hud/reborn/ability_bevel_psd.vtex");
+	background-size: contain;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	z-index: 1;
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #00FF0000 ), to( #00FF0000 ) );
+	visibility: visible;
+
+	transition-property: brightness, background-color;
+	transition-duration: .12s;
+	transition-timing-function: ease-in;
+}
+
+.Reborn #stash #AbilityBevel,
+.Reborn #QueryUnit #AbilityBevel
+{
+	visibility: collapse;
+}
+
+.Reborn #inventory #AbilityBevel
+{
+	margin: 0px;
+	background-image: url("s2r://panorama/images/hud/reborn/inventory_item_bevel_psd.vtex");
+}
+
+.Reborn #inventory .BackpackSlot #AbilityBevel
+{
+	background-image: none;
+}
+
+.Reborn #inventory .no_level #AbilityBevel
+{
+	background-image: none;
+}
+
+.Reborn #inventory .is_passive #AbilityBevel
+{
+	visibility: collapse;
+}
+
+.Reborn .ability_phase #AbilityBevel
+{
+	brightness: 3;
+	wash-color: #00ff00;
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #00FF0033 ), to( #00FF0000 ) );
+}
+
+
+.Reborn .ability_phase #AbilityStatusOverlay
+{
+	border: 0px solid transparent;
+}
+
+.Reborn .no_level:not(.show_level_up_frame) #AbilityBevel
+{
+	wash-color: #000000bb;
+}
+
+.Reborn .QueryUnit .no_level:not(.show_level_up_frame) #AbilityBevel
+{
+	wash-color: #00000000;
+}
+
+
+.Reborn .is_active #AbilityBevel
+{
+	brightness: 6;
+	transition-timing-function: ease-out;
+}
+
+
+.Reborn .insufficient_mana #AbilityBevel
+{
+	wash-color: #6095FD;
+	transition-timing-function: ease-out;
+}
+
+.Reborn .is_active #ItemImage,
+.Reborn .is_active #AbilityImage
+{
+	pre-transform-scale2d: 1.05;
+}
+
+
+
+
+.Reborn .is_active #ActiveAbility
+{
+	border: 0px solid transparent;
+	background-color: none;
+
+
+}
+
+.Reborn .is_passive.no_level:not(.show_level_up_frame) #AbilityImage
+{
+	margin: 7px;
+}
+
+.Reborn .QueryUnit .is_passive.no_level:not(.show_level_up_frame) #AbilityImage
+{
+	margin: 0px;
+}
+
+.Reborn .is_passive #AbilityBevel
+{
+	//visibility: collapse;
+	transform: rotateZ(180deg);
+	wash-color: #00000088;
+}
+
+.Reborn .QueryUnit .is_passive #AbilityBevel
+{
+	transform: rotateZ(0deg);
+	wash-color: #00000000;
+}
+
+
+.Reborn #ButtonWell
+{
+	width: 72px;
+	height: 72px;
+	width: 64px;
+	height: 64px;
+	vertical-align: bottom;
+	//border: 1px solid red;
+	background-image: url("s2r://panorama/images/hud/reborn/active_ability_border_psd.vtex");
+	background-size: 58px 58px;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	z-index: 0;
+}
+
+.Reborn .BackpackSlot #ButtonWell
+{
+	background-image: none;
+	box-shadow: inset #000 1px 2px 3px 3px;
+}
+
+
+
+
+.Reborn .is_passive #ButtonWell
+{
+	background-size: 18px 18px;
+}
+
+.Reborn #stash #ButtonWell,
+.Reborn #QueryUnit #ButtonWell,
+.Reborn #inventory #ButtonWell
+{
+	width: fit-children;
+	height: fit-children;
+	//border: 1px solid red;
+	background-size: 0px;
+}
+
+.Reborn #QueryUnit #Abilities #ButtonWell
+{
+	width: fit-children;
+	height: fit-children;
+}
+
+.Reborn #QueryUnit #Abilities #AbilityBevel
+{
+	visibility: visible;
+	margin: 0px;
+	background-image: url("s2r://panorama/images/hud/reborn/query_ability_bevel_psd.vtex");
+	background-size: 100%;
+
+}
+
+.Reborn .can_cast_again:not(.InventoryItem) #AbilityButton
+{
+	pre-transform-scale2d: .9;
+	transition-duration: .06s;
+}
+
+.Reborn .can_cast_again:not(.InventoryItem) #AbilityImage
+{
+	pre-transform-scale2d: 1;
+	contrast: .9;
+	saturation: .6;
+	wash-color: #000000a4;
+
+	pre-transform-scale2d: 1;
+	contrast: 1;
+	saturation: .6;
+	wash-color: #00000044;
+}
+
+.Reborn .can_cast_again.InventoryItem #AbilityButton
+{
+	pre-transform-scale2d: .9;
+	transition-duration: .06s;
+}
+
+.Reborn .can_cast_again.InventoryItem #ItemImage
+{
+	pre-transform-scale2d: 1;
+	contrast: 1;
+	saturation: .6;
+	//wash-color: #000000a4;
+}
+
+.Reborn .insufficient_mana.can_cast_again.InventoryItem #ItemImage
+{
+	pre-transform-scale2d: 1;
+	contrast: 1.2;
+	saturation: 0;
+	wash-color: #1569be;
+}
+
+.Reborn .insufficient_mana.can_cast_again:not(.InventoryItem) #AbilityImage
+{
+	wash-color: #1569be;
+}
+
+.Reborn #CooldownOverlay
+{
+	background-color: #000000dc;
+}
+
+.Reborn #AbilityLevelContainer
+{
+	margin-top: 0px;
+
+	margin-bottom: 4px;
+	margin-bottom: 6px;
+	margin-bottom: 16px;
+	background-color: none;
+	width: fit-children;
+	horizontal-align: center;
+}
+
+/* Added for AAA*/
+.Reborn .AbilityMaxLevel6 .LevelPanel
+{
+  margin: 3px 1px 3px 1px;
+}
+
+
+.Reborn .AbilityMaxLevel7 #AbilityLevelContainer
+{
+	margin-bottom: 18px;
+}
+
+.Reborn .QueryUnit #AbilityLevelContainer
+{
+	width: fit-children;
+	margin-bottom: 0px;
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #00000000 ), to( #000000ff ) );
+	horizontal-align: center;
+}
+
+#QueryLevelGradient
+{
+	width: 100%;
+	height: 16px;
+	vertical-align: bottom;
+	background-color: gradient( linear, 0% 0%, 0% 80%, from( #00000000 ), to( #000000ff ) );
+	visibility: collapse;
+}
+
+.Reborn .QueryUnit #Abilities #QueryLevelGradient
+{
+	visibility: visible;
+}
+
+.Reborn .QueryUnit #Abilities .enemy #QueryLevelGradient
+{
+	visibility: collapse;
+}
+
+.Reborn #ButtonAndLevel
+{
+	//background-color: black;
+	z-index: 1;
+}
+
+#inventory_slot_6 #ButtonAndLevel,
+#inventory_slot_7 #ButtonAndLevel,
+#inventory_slot_8 #ButtonAndLevel
+{
+	horizontal-align: center;
+}
+
+.Reborn .LevelPanel
+{
+	width: 8px;
+	height: 4px;
+	margin: 3px 2px 3px 2px;
+	border-radius: 1px;
+
+	background-image: none;
+	background-size: 100% 100%;
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #111111ff ), to( #000000ff ) );
+}
+
+.Reborn .AbilityMaxLevel7 .LevelPanel
+{
+	width: 5px;
+	height: 5px;
+	margin: 1.5px;
+}
+
+.Reborn .active_level.LevelPanel
+{
+	background-image: none;
+	background-size: 100% 100%;
+	background-position: 50% 50%;
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #E7D291 ), to( #887845 ) );
+	border-radius: 0px;
+}
+
+.Reborn .could_level_up .next_level.LevelPanel
+{
+	background-image: none;
+	border: 1px solid #dbb43466;
+	border-radius: 0px;
+	box-shadow: fill #E0C24E44 -1px -1px 2px 2px;
+	//height: 6px;
+}
+
+.Reborn .QueryUnit .could_level_up .next_level.LevelPanel
+{
+	background-image: none;
+	border: 1px solid #00000000;
+	border-radius: 0px;
+	box-shadow: fill #00000000 0px 0px 0px 0px;
+	//height: 6px;
+}
+
+.Reborn .InventoryItem #ButtonAndLevel
+{
+	background-color: none;
+}
+
+.Reborn .InventoryItem #ButtonSize
+{
+	width: 51px;
+	height: 39px;
+
+	width: 47px;
+	height: 36px;
+
+	width: 55px;
+	height: 42px;
+
+	width: 59px;
+	height: 45px;
+
+	background-size: cover;
+	overflow: noclip;
+    background-color: #1a1c1d88;
+
+	margin-left: 3px;
+	margin-right: 3px;
+	margin-top: 2px;
+	margin-bottom: 2px;
+
+	background-image: url("s2r://panorama/images/hud/reborn/inventory_item_well_psd.vtex");
+	box-shadow: fill #000000aa -1px -1px 2px 2px;
+}
+
+.Reborn .InventoryItem.is_passive #ButtonSize,
+.Reborn .InventoryItem.no_level #ButtonSize
+{
+	box-shadow: none;
+}
+
+.Reborn .InventoryItem:not(.no_level) #ButtonSize
+{
+	background-image: none;
+}
+
+.Reborn .InventoryItem.can_cast_again #ButtonSize,
+.Reborn .InventoryItem.is_passive #ButtonSize
+{
+	background-image: url("s2r://panorama/images/hud/reborn/inventory_item_well_psd.vtex");
+	box-shadow: fill #000000aa 0px 0px 0px 0px;
+}
+
+.Reborn .InventoryItem.is_passive #ButtonSize
+{
+	box-shadow: inset #000000aa 2px 2px 4px 4px;
+}
+
+
+.Reborn #center_block .InventoryItem.BackpackSlot #ButtonSize
+{
+	margin-top: 0px;
+	margin-bottom: 0px;
+	margin-left: 0px;
+	margin-right: 0px;
+	box-shadow: inset #000000 2px 2px 5px 5px;
+}
+
+
+
+.Reborn .InventoryItem.Stash #ButtonSize
+{
+	width: 38px;
+	height: 28px;
+	margin-left: 0px;
+	margin-right: 0px;
+    vertical-align: bottom;
+
+}
+
+.Reborn DOTAAbilityPanel.InventoryItem.Stash
+{
+	margin-right: 3px;
+}
+
+.Reborn #Hotkey
+{
+	margin-left: 0px;
+	margin-top: 0px;
+	background-color: #212726;
+	border-radius: 0px;
+	border: 0px;
+	box-shadow: fill #000000dd 0px 0px 2px 2px;
+	border-radius: 4px;
+	border: 1px solid black;
+}
+
+.LowVisualQuality #Hotkey
+{
+	border-radius: 0px;
+}
+
+.hotkey_ctrl #Hotkey
+{
+	margin-left: 31px;
+}
+
+.no_hotkey #Hotkey,
+.no_hotkey #HotkeyModifier
+{
+	visibility: collapse;
+}
+
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #Hotkey,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #Hotkey,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #Hotkey,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #Hotkey
+{
+	margin-left: 0px;
+	margin-top: 10px;
+
+}
+
+
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2 #HotkeyModifier,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3 #HotkeyModifier,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3 #HotkeyModifier,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4 #HotkeyModifier
+{
+	margin-top: 11px;
+
+}
+
+.Reborn .HasMorph .toggle_enabled:not(.InventoryItem) #AbilityButton
+{
+	pre-transform-scale2d: .9;
+	brightness: 1.6;
+	contrast: 1;
+	saturation: 1.2;
+}
+
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability2.toggle_enabled:not(.InventoryItem) #AbilityButton,
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability3.toggle_enabled:not(.InventoryItem) #AbilityButton
+{
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #00ff00 ), to( #000000 ) );
+}
+
+.Reborn .npc_dota_hero_rubick.HasMorph #Ability4.toggle_enabled:not(.InventoryItem) #AbilityButton,
+.Reborn .npc_dota_hero_morphling.HasMorph #Ability3.toggle_enabled:not(.InventoryItem) #AbilityButton
+{
+	background-color: gradient( linear, 0% 0%, 0% 100%, from( #ff0000 ), to( #000000 ) );
+}
+
+.HasMorph .toggle_enabled #AbilityStatusOverlay
+{
+	border: 0px solid transparent;
+}
+
+
+.npc_dota_hero_rubick #Ability3.no_level.AbilityMaxLevel0 #AbilityImage,
+.npc_dota_hero_rubick #Ability4.no_level.AbilityMaxLevel0 #AbilityImage
+{
+	opacity: .6;
+}
+
+.npc_dota_hero_rubick #Ability3.no_level.AbilityMaxLevel0 #ButtonWell,
+.npc_dota_hero_rubick #Ability4.no_level.AbilityMaxLevel0 #ButtonWell
+{
+	background-image: none;
+}
+
+.Reborn #HotkeyModifier
+{
+	margin-left: 0px;
+	margin-top: 14px;
+	background-color: #212726;
+	box-shadow: fill #000000dd 0px 0px 2px 2px;
+	border-radius: 2px;
+	border: 1px solid black;
+}
+
+.hotkey_ctrl.hotkey_alt #HotkeyModifier
+{
+	min-width: 22px;
+}
+
+.Reborn .InventoryItem #HotkeyModifier
+{
+	margin-left: -4px;
+	margin-top: 10px;
+}
+
+.Reborn .InventoryItem #Hotkey
+{
+	margin-top: -2px;
+	margin-left: -2px;
+	background-color: #2127268a;
+	box-shadow: fill #000000dd 0px 0px 1px 1px;
+	border-radius: 4px;
+
+	border-radius: 2px;
+
+	border: 1px solid black;
+}
+
+.InventoryItem #ButtonWithLevelUpTab
+{
+	padding-left: 0px;
+	padding-right: 0px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+}
+
+.Reborn DOTAAbilityPanel.InventoryItem
+{
+	vertical-align: top;
+}
+
+.Reborn DOTAAbilityPanel.InventoryItem.BackpackSlot
+{
+	horizontal-align: right;
+}
+
+.QueryUnit #LevelUpLight,
+.InventoryItem #LevelUpLight,
+.InventoryItem #LevelUpTab
+{
+	visibility: collapse;
+}
+
+.Reborn #HotkeyText
+{
+	color: white;
+}
+
+.Reborn .InventoryItem #HotkeyText
+{
+	min-width: 14px;
+}
+
+.Reborn #AltText
+{
+	color: white;
+}
+
+.Reborn .hotkey_ctrl.hotkey_alt #AltText
+{
+	font-size: 11px;
+}
+
+.Reborn #ManaCostBG
+{
+    background-image: url("s2r://panorama/images/hud/reborn/manaamount_bg_png.vtex");
+	margin-right: -2px;
+	margin-bottom: -1px;
+}
+
+.Reborn #ManaCost
+{
+    color: #57b7ff;
+	font-size: 14px;
+	font-weight: thin;
+	font-weight: normal;
+    margin-right: 8px;
+	margin-bottom: 4px;
+}
+
+.Reborn .InventoryItem #ManaCost
+{
+	//font-size: 10px;
+}
+
+.Reborn #GoldCost
+{
+	margin-left: 0px;
+	margin-bottom: -1px;
+}
+
+.Reborn #GoldCostBG
+{
+	margin-left: 0px;
+	margin-bottom: -8px;
+}
+
+//----------------------------------------------------------------------
+// Reborn Query Unit
+
+.Reborn .QueryUnit #ButtonSize
+{
+	width: 64px;
+	height: 64px;
+
+	width: 39px;
+	height: 39px;
+}
+
+
+.Reborn .QueryUnit DOTAAbilityPanel
+{
+	vertical-align: top;
+}
+
+.Reborn .QueryUnit #Abilities DOTAAbilityPanel
+{
+	box-shadow: fill #000000 -1.5px -1.5px 3px 3px;
+}
+
+
+
+.Reborn .FiveAbilities.QueryUnit #ButtonSize
+{
+	width: 54px;
+	height: 54px;
+}
+
+.Reborn .SixAbilities.QueryUnit #ButtonSize
+{
+	width: 48px;
+	height: 48px;
+}
+
+.Reborn .QueryUnit .InventoryItem #ButtonSize
+{
+	width: 45px;
+	height: 33px;
+	margin: 0px;
+    background-color: #1a1c1dbb;
+}
+
+.Reborn .QueryUnit #stash_row .InventoryItem #ButtonSize
+{
+	width: 40px;
+	height: 30px;
+	margin: 0px;
+}
+
+.Reborn .QueryUnit .InventoryItem.BackpackSlot #ButtonSize
+{
+	//width: 40px;
+	height: 36px;
+	margin: 0px;
+}
+
+.Reborn .QueryUnit #AbilityImage,
+.Reborn .QueryUnit #Cooldown
+{
+	margin: 0px;
+}
+
+.Reborn .QueryUnit #Hotkey,
+.Reborn .QueryUnit #HotkeyModifier,
+.Reborn .QueryUnit #ManaCost,
+.Reborn .QueryUnit #ManaCostBG,
+.Reborn .QueryUnit #GoldCost,
+.Reborn .QueryUnit #GoldCostBG,
+.Reborn .QueryUnit #ActiveAbilityBorder,
+.Reborn .QueryUnit #PassiveAbilityBorder,
+.Reborn .QueryUnit #SilencedOverlay,
+.Reborn .QueryUnit #CombineLockedOverlay,
+.Reborn .QueryUnit #AbilityStatusOverlay
+{
+	visibility: collapse;
+}
+
+.Reborn .QueryUnit  .level_secret.no_level:not(.show_level_up_frame) #AbilityImage
+{
+	saturation: 1.0;
+	wash-color: unlearnedWashColor;
+    brightness: 1.2;
+}
+
+.Reborn .QueryUnit .enemy.level_secret.no_level:not(.show_level_up_frame) #AbilityImage
+{
+	saturation: 0.3;
+	brightness: 2.2;
+}
+
+.Reborn .QueryUnit.IsNeutral .enemy.level_secret.no_level:not(.show_level_up_frame) #AbilityImage
+{
+	saturation: 1;
+	brightness: 1;
+	wash-color: none;
+}
+
+.Reborn #UpgradeOverlay
+{
+    margin: 0px;
+}
+
+.Reborn .QueryUnit .LevelPanel
+{
+	width: 7px;
+	height: 3px;
+	margin: 1px;
+	margin-left: 1.5px;
+	margin-right: 1.5px;
+	border-radius: 0px;
+    background-color: gradient( linear, 0% 0%, 0% 100%, from( #363636ff ), to( #3e3e3eff ) );
+}
+
+.Reborn .QueryUnit .active_level.LevelPanel
+{
+    background-color: gradient( linear, 0% 0%, 0% 100%, from( #E7D291 ), to( #887845 ) );
+}
+.Reborn .QueryUnit.FiveQueryAbilities .LevelPanel
+{
+	width: 7px;
+	height: 3px;
+	margin-left: 1.5px;
+	margin-right: 1.5px;
+}
+
+.Reborn .QueryUnit .AbilityMaxLevel7 .LevelPanel
+{
+	width: 3px;
+	height: 3px;
+	margin: 0px 1px 1px 1px;
+
+}
+
+.Reborn .QueryUnit #Abilities #CooldownTimer
+{
+    margin-top: 6px;
+}
+
+.Reborn .QueryUnit .enemy #AbilityImage
+{
+	saturation: 0;
+}
+
+.QueryUnit #ButtonWithLevelUpTab
+{
+	padding-left: 0px;
+	padding-right: 0px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+}
+
+.QueryUnit #LevelUpTab
+{
+	visibility: collapse;
+}
+
+#InvokerSpellCard
+{
+	background-image: url("s2r://panorama/images/hud/invokercard_psd.vtex");
+	background-size: 100%;
+	height: 28px;
+	width: 68px;
+	horizontal-align: center;
+	vertical-align: middle;
+	margin-top: -3px;
+	z-index: 0;
+	//transform: rotateZ(-90deg);
+
+	transition-property: brightness, saturation;
+	transition-duration: .18s;
+	transition-timing-function: ease-in-out;
+}
+
+#SpellsLabel
+{
+	font-size: 14px;
+	text-transform: uppercase;
+	horizontal-align: center;
+	text-align: center;
+	vertical-align: middle;
+	text-shadow: 0px 0px 3px 3 #00000033;
+	color: #ffffff;
+	color: black;
+	font-weight: bold;
+	width: 58px;
+	height: 20px;
+	text-overflow: shrink;
+}
+
+.QueryUnit #InvokerSpellCard
+{
+	visibility: collapse;
+}
+
+#InvokerSpellCard:hover
+{
+	brightness: 2;
+	saturation: 1.3;
+}
+
+
+#InvokerSpellCard:hover #SpellsLabel
+{
+	color: #cccccc;
+}
+
+#InvokerSpellCard.Hidden
+{
+	visibility: collapse;
+}
+
+#LevelUpBurstFXContainer
+{
+	width: 100%;
+	height: 80px;
+	visibility: collapse;
+	//border: 1px solid black;
+
+}
+
+#LevelUpBurstFX
+{
+	width: 100%;
+	height: 100%;
+}
+
+#abilities .show_level_up_tab #LevelUpBurstFXContainer
+{
+	visibility: visible;
+}
+
+#QueryUnit #LevelUpBurstFXContainer
+{
+	visibility: collapse;
+}
+
+#TopBarUltimate #ButtonWell
+{
+	background-image: none;
+
+}
+
+#TopBarUltimate #AbilityImage
+{
+	margin: 0px;
+	border-radius: 50%;
+	margin: 1px;
+}
+
+#ADAbilityContainer #AbilityImage
+{
+	margin: 0px;
+	margin: 1px;
+}
+
+#TopBarUltimate #TopBarUltimateCooldown
+{
+	visibility: visible;
+}
+
+#TopBarUltimateCooldown
+{
+	visibility: collapse;
+	width: 100%;
+	height: 100%;
+	border: 2px solid #11D444;
+	border-radius: 50%;
+	margin: 1px;
+}
+
+#TopBarUltimate.insufficient_mana #TopBarUltimateCooldown
+{
+	border-color: #3285BC;
+}
+
+#TopBarUltimate #AbilityButton
+{
+	background-color: none;
+	pre-transform-scale2d: 1;
+
+}
+
+#TopBarUltimate #CooldownOverlay
+{
+	border-radius: 50%;
+	border: 5px solid #000000;
+	background-color: none;
+
+	margin: 0px;
+}
+
+#TopBarUltimate #Cooldown
+{
+	margin: 0px;
+}
+
+
+
+
+
+#ADAbilityContainer #ShineContainer,
+#ADAbilityContainer #ActiveAbilityBorder,
+#ADAbilityContainer #ActiveAbility,
+#ADAbilityContainer #Charges,
+#ADAbilityContainer #AltCharges,
+#ADAbilityContainer #AbilityBevel,
+#ADAbilityContainer #Hotkey,
+#ADAbilityContainer #HotkeyModifier,
+#ADAbilityContainer #ManaCost,
+#ADAbilityContainer #ManaCostBG,
+#ADAbilityContainer #AutoCasting,
+#ADAbilityContainer #AutocastableBorder,
+#ADAbilityContainer #LevelUpLight,
+#ADAbilityContainer #LevelUpTab,
+#ADAbilityContainer #AbilityLevelContainer,
+#TopBarUltimate #ShineContainer,
+#TopBarUltimate #ActiveAbilityBorder,
+#TopBarUltimate #ActiveAbility,
+#TopBarUltimate #Charges,
+#TopBarUltimate #AltCharges,
+#TopBarUltimate #AbilityBevel,
+#TopBarUltimate #Hotkey,
+#TopBarUltimate #HotkeyModifier,
+#TopBarUltimate #ManaCost,
+#TopBarUltimate #ManaCostBG,
+#TopBarUltimate #AutoCasting,
+#TopBarUltimate #AutocastableBorder,
+#TopBarUltimate #LevelUpLight,
+#TopBarUltimate #LevelUpTab,
+#TopBarUltimate #AbilityLevelContainer
+{
+	visibility: collapse;
+}
+
+#TopBarUltimate #ButtonAndLevel
+{
+	border-radius: 50%;
+	border: 2px solid black;
+	box-shadow: fill #000000da -2px -2px 4px 4px;
+}
+
+#TopBarUltimate #CooldownTimer
+{
+	margin-top: 4px;
+	margin-left: 1px;
+	text-align: center;
+}
+
+.Reborn DOTAScoreboardPlayerInventory .InventoryItem #ButtonSize
+{
+	width: 47px;
+	height: 32px;
+}
+
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardBackpack .InventoryItem #ButtonSize
+{
+	width: 40px;
+	height: 22px;
+	border-bottom: 1px solid black;
+	//background-color: black;
+}
+
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardBackpack .InventoryItem
+{
+	margin-left: 18px;
+}
+
+
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardBackpack .inactive_item #AbilityButton
+{
+	saturation: 0.25;
+}
+
+.Reborn DOTAScoreboardPlayerInventory #Charges
+{
+	//font-weight: normal;
+	font-size: 14px;
+}
+
+
+.Reborn DOTAScoreboardPlayerInventory #HotKey,
+.Reborn DOTAScoreboardPlayerInventory #HotKeyModifier,
+.Reborn DOTAScoreboardPlayerInventory #HotKeyCtrlModifier,
+.Reborn DOTAScoreboardPlayerInventory #AbilityBevel
+{
+	visibility: collapse;
+}
+
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardStash #ButtonSize,
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardStash #ButtonWell,
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardStash #AbilityButton,
+.Reborn DOTAScoreboardPlayerInventory #ScoreboardStash #ActiveAbility
+{
+	box-shadow: none;
+	background-color: none;
+	background-image: none;
+}

--- a/content/panorama/styles/hud/dota_hud_ability_panel.css
+++ b/content/panorama/styles/hud/dota_hud_ability_panel.css
@@ -1672,7 +1672,7 @@ DOTAAbilityPanel.Hidden
 	horizontal-align: center;
 }
 
-/* AAA 5/6 level ability level indicator styling*/
+/* OAA 5/6 level ability level indicator styling*/
 .Reborn .AbilityMaxLevel6 .LevelPanel
 {
   width: 7px;
@@ -1697,7 +1697,7 @@ DOTAAbilityPanel.Hidden
 {
   margin-left: 1px;
 }
-/* End of AAA 5/6 level ability level indicator styling*/
+/* End of OAA 5/6 level ability level indicator styling*/
 
 .Reborn .AbilityMaxLevel7 #AbilityLevelContainer
 {

--- a/content/panorama/styles/hud/dota_hud_ability_panel.css
+++ b/content/panorama/styles/hud/dota_hud_ability_panel.css
@@ -1672,13 +1672,32 @@ DOTAAbilityPanel.Hidden
 	horizontal-align: center;
 }
 
-/* Added for AAA*/
+/* AAA 5/6 level ability level indicator styling*/
 .Reborn .AbilityMaxLevel6 .LevelPanel
 {
   width: 7px;
   margin: 3px 1.5px 3px 1.5px;
 }
 
+.Reborn .QueryUnit .AbilityMaxLevel6 .LevelPanel
+{
+  width: 3px;
+  height: 3px;
+  margin: 0px 1.4px 1px 1.4px;
+}
+
+.Reborn .QueryUnit .AbilityMaxLevel5 .LevelPanel
+{
+  width: 4px;
+  height: 3px;
+  margin: 0px 1px 1px 1px;
+}
+
+.Reborn .QueryUnit .AbilityMaxLevel6 #AbilityLevelContainer
+{
+  margin-left: 1px;
+}
+/* End of AAA 5/6 level ability level indicator styling*/
 
 .Reborn .AbilityMaxLevel7 #AbilityLevelContainer
 {


### PR DESCRIPTION
* Add dota_hud_ability_panel.css
  Lines 1676-1679 are the important bit. The rest is extracted from vanilla Dota.

Note: If Valve decide to change this file (in vanilla Dota) for whatever reason, it will likely need to be updated with the changes.